### PR TITLE
Arabic_tibetian_lunar_mansions

### DIFF
--- a/Arabic_tibetian_lunar_mansions
+++ b/Arabic_tibetian_lunar_mansions
@@ -1,0 +1,983 @@
+[
+  {"constellation": "الحمل", "lines": [[0,1],[1,2]]},
+  {"constellation": "الثور", "lines": [[0,1],[1,2]]},
+  {"constellation": "الجوزاء", "lines": [[0,1],[1,2]]},
+  {"constellation": "السرطان", "lines": [[0,1],[1,2]]},
+  {"constellation": "الأسد", "lines": [[0,1],[1,2]]},
+  {"constellation": "العذراء", "lines": [[0,1],[1,2]]},
+  {"constellation": "الميزان", "lines": [[0,1],[1,2]]},
+  {"constellation": "العقرب", "lines": [[0,1],[1,2]]},
+  {"constellation": "القوس", "lines": [[0,1],[1,2]]},
+  {"constellation": "الجدي", "lines": [[0,1],[1,2]]},
+  {"constellation": "الدلو", "lines": [[0,1],[1,2]]},
+  {"constellation": "الحوت", "lines": [[0,1],[1,2]]},
+  {"constellation": "CON arabic_indigenous Naqa", "lines": [[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],[10,12],[11,15,13],[15,16,14],[16,"DSO:NGC869"],[17,18],[19,20]]},
+  {"constellation": "CON arabic_indigenous RNaq", "lines": [[0,1,2,3]]},
+  {"constellation": "CON arabic_indigenous UNaq", "lines": [[0,1,2,3,4,5,6,7]]},
+  {"constellation": "CON arabic_indigenous YNaq", "lines": [[0,1],[2,3]]},
+  {"constellation": "CON arabic_indigenous SNaq", "lines": [[0,1,2,3,4,5,6],[6,0]]},
+  {"constellation": "CON arabic_indigenous ThuI", "lines": [[0,1,2],[0,3,4],[0,5,4],[5,6,7,8,9,8,10,11,12,13,14,15,16,17,18,19,20,21,22,23,13],[18,24,0],[18,25,26,22,0]]}
+]
+
+===============================
+Arabic_Tibetian_Lunar_Mansions
+===============================
+
+## Title
+Creating an Astronomical Culture Combining Tibetan Zodiac with Arabic Lunar Mansions
+
+## Project
+Hybrid Astronomical Culture – Moon Houses in Samarra
+
+## Author
+- Physicist Omar Al-Baz
+- Senior Chief Programmer – North Transmission Electricity Company
+- Salah Al-Din Electricity Network Department
+- Member of the Arab Union for Space and Astronomy
+- Researcher in Metaphysical Sciences
+- Astronomical Designer and Photographer
+
+📧 Email: omaralbaz127@gmail.com
+📱 Phone: +9647716890986
+
+## Purpose of the Culture
+This developed astronomical culture was born to redraw the sky in the language of the Arabs,
+a language that can be read, seen, and felt, woven between lunar mansions and Tibetan zodiac,
+in a cosmic fabric that unites science and art, heritage and modernity.
+
+It is not just lines between stars, but a celestial poem,
+a mirror of identity, and a bridge between past and future.
+It aims to honor Arab heritage, integrate Tibetan zodiac,
+and add modern Greek colors that bring beauty and serenity,
+to make the astronomical culture a complete cosmic painting.
+
+## Lunar Mansions
+28 mansions from Al-Sharatain to Al-Fargh Al-Mu’akhkhar, each carrying a symbol and wisdom.
+
+## Tibetan Zodiac
+Integrated with Arabic mansions to create a hybrid vision
+that honors heritage and opens doors to the future.
+
+## Vision
+- Science can be beautiful
+- Heritage can live in a modern language
+- The sky is a mirror of identity and a bridge between past and future
+
+## References
+1. Burgess, E. (1860). Surya-Siddhanta – Hindu Astronomy.
+2. Cornu, P. (2002). Tibetan Astrology. Shambhala.
+3. Reingold & Dershowitz (2018). Calendrical Calculations. Cambridge University Press.
+
+## Copyright
+CC BY-SA
+Location: Samarra – Iraq
+Signature: Omar Al-Baz
+
+===============================
+Arabic_Tibetian_Lunar_Mansions
+===============================
+
+النسخة العربية
+--------------
+
+## العنوان
+إنشاء ثقافة فلكية تجمع الأبراج التبتية بمنازل القمر العربية
+
+## المشروع
+تطوير ثقافة فلكية هجينة – Moon Houses in Samarra
+
+## المؤلف
+- الفيزيائي عمر الباز
+- رئيس مبرمجين أقدم – شركة نقل الشمال للطاقة الكهربائية
+- قسم شبكة كهرباء صلاح الدين
+- عضو الاتحاد العربي لعلوم الفضاء والفلك
+- باحث في علوم ما وراء الطبيعة
+- مصمم ومصور فلكي
+
+📧 البريد الإلكتروني: omaralbaz127@gmail.com
+📱 رقم الهاتف: 009647716890986
+
+## الغرض من الثقافة
+هذه النسخة المطوّرة من الثقافة الفلكية وُلدت لتعيد رسم السماء بلغة العرب،
+لغة تُقرأ وتُرى وتُحس، منسوجة بين المنازل القمرية والأبراج التبتية،
+في نسيج كوني واحد يجمع بين العلم والفن، بين التراث والحداثة.
+
+إنها ليست مجرد خطوط بين النجوم، بل قصيدة سماوية،
+مرآة للهوية، وجسر بين الماضي والمستقبل.
+تهدف إلى تكريم التراث العربي، ودمج الأبراج التبتية،
+وإضافة ألوان يونانية حديثة تمنح إحساساً بالجمال والسكينة،
+لتكون الثقافة الفلكية لوحة كونية متكاملة.
+
+## المنازل القمرية
+28 منزلاً من الشرطين إلى الفرغ المؤخر، كل منزل يحمل رمزاً وحكمة.
+
+## الأبراج التبتية
+تتكامل مع المنازل العربية لتصنع رؤية هجينة
+تكرّم التراث وتفتح أبواب المستقبل.
+
+## الرؤية
+- العلم يمكن أن يكون جميلاً
+- التراث يمكن أن يعيش في لغة حديثة
+- السماء مرآة الهوية وجسر بين الماضي والمستقبل
+
+## المراجع
+1. Burgess, E. (1860). Surya-Siddhanta – Hindu Astronomy.
+2. Cornu, P. (2002). Tibetan Astrology. Shambhala.
+3. Reingold & Dershowitz (2018). Calendrical Calculations. Cambridge University Press.
+
+## حقوق النشر
+CC BY-SA
+المكان: سامراء – العراق
+التوقيع: عمر الباز
+
+
+===============================
+English Version
+===============================
+
+## Title
+Creating an Astronomical Culture Combining Tibetan Zodiac with Arabic Lunar Mansions
+
+## Project
+Hybrid Astronomical Culture – Moon Houses in Samarra
+
+## Author
+- Physicist Omar Al-Baz
+- Senior Chief Programmer – North Transmission Electricity Company
+- Salah Al-Din Electricity Network Department
+- Member of the Arab Union for Space and Astronomy
+- Researcher in Metaphysical Sciences
+- Astronomical Designer and Photographer
+
+📧 Email: omaralbaz127@gmail.com
+📱 Phone: +9647716890986
+
+## Purpose of the Culture
+This developed astronomical culture was born to redraw the sky in the language of the Arabs,
+a language that can be read, seen, and felt, woven between lunar mansions and Tibetan zodiac,
+in a cosmic fabric that unites science and art, heritage and modernity.
+
+It is not just lines between stars, but a celestial poem,
+a mirror of identity, and a bridge between past and future.
+It aims to honor Arab heritage, integrate Tibetan zodiac,
+and add modern Greek colors that bring beauty and serenity,
+to make the astronomical culture a complete cosmic painting.
+
+## Lunar Mansions
+28 mansions from Al-Sharatain to Al-Fargh Al-Mu’akhkhar, each carrying a symbol and wisdom.
+
+## Tibetan Zodiac
+Integrated with Arabic mansions to create a hybrid vision
+that honors heritage and opens doors to the future.
+
+## Vision
+- Science can be beautiful
+- Heritage can live in a modern language
+- The sky is a mirror of identity and a bridge between past and future
+
+## References
+1. Burgess, E. (1860). Surya-Siddhanta – Hindu Astronomy.
+2. Cornu, P. (2002). Tibetan Astrology. Shambhala.
+3. Reingold & Dershowitz (2018). Calendrical Calculations. Cambridge University Press.
+
+## Copyright
+CC BY-SA
+Location: Samarra – Iraq
+Signature: Omar Al-Baz
+
+[
+  {"constellation": "CON tibetan Ari", "lines": [[0,1],[1,2]]},
+  {"constellation": "CON tibetan Tau", "lines": [[0,1],[1,2]]},
+  {"constellation": "CON tibetan Gem", "lines": [[0,1],[1,2]]},
+  {"constellation": "CON tibetan Cnc", "lines": [[0,1],[1,2]]},
+  {"constellation": "CON tibetan Leo", "lines": [[0,1],[1,2]]},
+  {"constellation": "CON tibetan Vir", "lines": [[0,1],[1,2]]},
+  {"constellation": "CON tibetan Lib", "lines": [[0,1],[1,2]]},
+  {"constellation": "CON tibetan Sco", "lines": [[0,1],[1,2]]},
+  {"constellation": "CON tibetan Sgr", "lines": [[0,1],[1,2]]},
+  {"constellation": "CON tibetan Cap", "lines": [[0,1],[1,2]]},
+  {"constellation": "CON tibetan Aqr", "lines": [[0,1],[1,2]]},
+  {"constellation": "CON tibetan Psc", "lines": [[0,1],[1,2]]},
+
+  {"constellation": "CON arabic_indigenous Naqa", "lines": [[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],[10,12],[11,15,13],[15,16,14],[16,"DSO:NGC869"],[17,18],[19,20]]},
+  {"constellation": "CON arabic_indigenous RNaq", "lines": [[0,1,2,3]]},
+  {"constellation": "CON arabic_indigenous UNaq", "lines": [[0,1,2,3,4,5,6,7]]},
+  {"constellation": "CON arabic_indigenous YNaq", "lines": [[0,1],[2,3]]},
+  {"constellation": "CON arabic_indigenous SNaq", "lines": [[0,1,2,3,4,5,6],[6,0]]},
+  {"constellation": "CON arabic_indigenous ThuI", "lines": [[0,1,2],[0,3,4],[0,5,4],[5,6,7,8,9,8,10,11,12,13,14,15,16,17,18,19,20,21,22,23,13],[18,24,0],[18,25,26,22,0]]}
+]
+
+{
+  "id": "Arabic_tibetian_lunar_mansions",
+  "region": "Arab World",
+  "classification": ["ethnographic"],
+  "fallback_to_international_names": false,
+  "constellations": {
+    "description": "Constellations organized into multiple sections for easier management",
+    "sections": [
+      {
+        "section_id": "arabic_core",
+        "title_ar": "المجموعة العربية الأساسية",
+        "title_en": "Arabic Core",
+        "constellations": [
+          {
+            "id": "CON arabic_indigenous Naqa",
+            "lines": [
+              [116631, 116805, 116584, 117221, 841, 2225, 2900, 3414, 3504, 3300, 2920, 3179, 746, 2599, 8886],
+              [2920, 746],
+              [3179, 4427, 2599],
+              [4427, 6686, 8886],
+              [6686, "DSO:NGC869"],
+              [5251, 8068],
+              [4998, 7607]
+            ],
+            "common_name": {
+              "english": "The She-Camel",
+              "native": "الناقة",
+              "pronounce": "al-Nāqah",
+              "transliteration": "al-Nāqah",
+              "IPA": "an.naː.qah",
+              "references": [1,2,4]
+            }
+          },
+          {
+            "id": "CON arabic_indigenous RNaq",
+            "lines": [[116631, 116805, 116584, 117221]],
+            "common_name": {
+              "english": "Head Of The She-Camel",
+              "native": "رأس الناقة",
+              "pronounce": "Ra's al-Nāqah",
+              "transliteration": "Raʾs al-Nāqah",
+              "IPA": "raʔ.su.n.naː.qa.h",
+              "references": [1,2,4]
+            }
+          },
+          {
+            "id": "CON arabic_indigenous UNaq",
+            "lines": [[117221, 841, 2225, 2900, 3414, 3504, 3300, 2920]],
+            "common_name": {
+              "english": "Neck Of The She-Camel",
+              "native": "عنق الناقة",
+              "pronounce": "'Unuq al-Nāqah",
+              "transliteration": "ʿUnuq al-Nāqah",
+              "IPA": "ʕu.nu.qu.n.naː.qah",
+              "references": [1,2,4]
+            }
+          },
+          {
+            "id": "CON arabic_indigenous YNaq",
+            "lines": [[5251, 8068], [4998, 7607]],
+            "common_name": {
+              "english": "Legs Of The She-Camel",
+              "native": "يدا الناقة",
+              "pronounce": "Yadā al-Nāqah",
+              "transliteration": "Yadā al-Nāqah",
+              "IPA": "ja.daːn.naː.qah",
+              "references": [4]
+            }
+          },
+          {
+            "id": "CON arabic_indigenous SNaq",
+            "lines": [[2920, 746, 2599, 8886, 6686, 4427, 3179, 2920]],
+            "common_name": {
+              "english": "The She-Camel's Hump",
+              "native": "سنام الناقة",
+              "pronounce": "Sanām al-Nāqah",
+              "transliteration": "Sanām al-Nāqah",
+              "IPA": "sa.naːmun.naː.qah",
+              "references": [1,2,3,4]
+            }
+          },
+          {
+            "id": "CON arabic_indigenous ThuI",
+            "lines": [
+              [14135, 13954, 12828],
+              [14135, 12706, 11484],
+              [14135, 12387, 11484],
+              [746, 3179, 4427, 6686, 8886, 6686, "DSO:NGC869", "DSO:NGC884", 13268, 14328, 17358, 18532, 18614, 18246, "DSO:M45", 17448, 17460, 17529, 16335, 15863, 14328],
+              ["DSO:M45", 16369, 14135],
+              ["DSO:M45", 16322, 16083, 15900, 14135]
+            ],
+            "label_positions": [[3.72, 24.37], [3.45, 12.74], [2.72, 55.10]],
+            "common_name": {
+              "english": "Al-Thurayya [The head and the two hands]",
+              "native": "الثريا [الرأس واليدان]",
+              "pronounce": "al-Thurayyā [al-Ra's wa al-Yadān]",
+              "transliteration": "al-Ṯurayyā [al-Raʾs wa al-Yadān]",
+              "IPA": "aθθu.rajj.jaː [ar.raʔ.su.wal.yadaːn]",
+              "references": [1,2,3,4]
+            }
+          }
+        ]
+      },
+      {
+        "section_id": "tibetan_core",
+        "title_ar": "المجموعة التبتية الأساسية",
+        "title_en": "Tibetan Core",
+        "constellations": [
+          {
+            "id": "CON tibetan Lib",
+            "lines": [[77853, 76333, 74785, 72622, 73714, 76333]],
+            "image": {
+              "file": "illustrations/libra.png",
+              "size": [256, 256],
+              "anchors": [
+                {"pos": [41, 27], "hip": 74785},
+                {"pos": [58, 170], "hip": 77853},
+                {"pos": [224, 107], "hip": 73714}
+              ]
+            },
+            "common_name": {"english": "Libra", "pronounce": "Sangwa"}
+          },
+          {
+            "id": "CON tibetan Ari",
+            "lines": [[13209, 9884, 8903, 8832]],
+            "image": {
+              "file": "illustrations/aries.png",
+              "size": [256, 256],
+              "anchors": [
+                {"pos": [12, 130], "hip": 13209},
+                {"pos": [58, 206], "hip": 13914},
+                {"pos": [210, 47], "hip": 8832}
+              ]
+            },
+            "common_name": {"english": "Aries", "pronounce": "Luk"}
+          },
+          {
+            "id": "CON tibetan Gem",
+            "lines": [[31681, 34088, 35550, 35350, 32362], [35550, 36962, 37740], [36962, 37826], [36962, 36046, 34693, 36850], [34693, 33018], [34693, 32246, 30883], [32246, 30343, 29655, 28734]],
+            "image": {
+              "file": "illustrations/gemini.png",
+              "size": [256, 256],
+              "anchors": [
+                {"pos": [14, 81], "hip": 37740},
+                {"pos": [117, 252], "hip": 32362},
+                {"pos": [249, 165], "hip": 28734}
+              ]
+            },
+            "common_name": {"english": "Gemini", "pronounce": "Trik"}
+          },
+          {
+            "id": "CON tibetan Leo",
+            "lines": [[57632, 54879, 49669, 49583, 50583, 54872, 57632], [50583, 50335, 48455, 47908], [54872, 54879]],
+            "image": {
+              "file": "illustrations/leo.png",
+              "size": [512, 512],
+              "anchors": [
+                {"pos": [69, 411], "hip": 57632},
+                {"pos": [383, 186], "hip": 49669},
+                {"pos": [321, 32], "hip": 47908}
+              ]
+            },
+            "common_name": {"english": "Leo", "pronounce": "Senge"}
+          },
+          {
+            "id": "CON tibetan Vir",
+            "lines": [[57380, 60030, 61941, 65474, 69427, 69701, 71957], [65474, 66249, 68520, 72220], [66249, 63090, 63608], [63090, 61941]],
+            "image": {
+              "file": "illustrations/virgo.png",
+              "size": [512, 512],
+              "anchors": [
+                {"pos": [65, 389], "hip": 72220},
+                {"pos": [454, 57], "hip": 57380},
+                {"pos": [338, 382], "hip": 65474}
+              ]
+            },
+            "common_name": {"english": "Virgo", "pronounce": "Pumo"}
+          }
+        ]
+      },
+      {
+        "section_id": "orientation_and_misc",
+        "title_ar": "عناصر توجيهية ومتفرقة",
+        "title_en": "Orientation and Misc",
+        "constellations": [
+          {
+            "id": "CON tibetan Boo",
+            "lines": [[71795, 69673, 72105, 74666, 73555, 71075, 71053, 69673, 67927, 67459]],
+            "common_name": {"english": ""},
+            "comment": "For orientation only. Non-Tibetan!"
+          },
+          {
+            "id": "CON tibetan Cnc",
+            "lines": [[43103, 42806, 40843], [42806, 42911, 40526], [42911, 44066]],
+            "image": {
+              "file": "illustrations/cancer.png",
+              "size": [256, 256],
+              "anchors": [
+                {"pos": [29, 166], "hip": 44066},
+                {"pos": [101, 255], "hip": 40526},
+                {"pos": [206, 91], "hip": 40843}
+              ]
+            },
+            "common_name": {"english": "Cancer", "pronounce": "Karkata"}
+          },
+          {
+            "id": "CON tibetan Psc",
+            "lines": [[4889, 5742], [4889, 6193, 5742, 7097, 8198, 9487, 8833, 7884, 7007, 4906, 3760, 1645, 118268, 116771, 116928, 115738, 114971, 115830, 116771]],
+            "image": {
+              "file": "illustrations/pisces.png",
+              "size": [512, 512],
+              "anchors": [
+                {"pos": [24, 104], "hip": 4889},
+                {"pos": [111, 489], "hip": 9487},
+                {"pos": [481, 155], "hip": 114971}
+              ]
+            },
+            "common_name": {"english": "Pisces", "pronounce": "Nya"}
+          },
+          {
+            "id": "CON tibetan Sgr",
+            "lines": [[89931, 90496], [89642, 90185, 88635, 87072], [88635, 89931, 90185, 93506, 92041, 89931], [92041, 90496, 89341], [93506, 93864, 92855, 92041], [92855, 93085, 93683, 94820, 95168], [93864, 96406, 98688, 98412, 98032, 95347], [98032, 95294]],
+            "image": {
+              "file": "illustrations/sagittarius.png",
+              "size": [512, 512],
+              "anchors": [
+                {"pos": [96, 82], "hip": 95168},
+                {"pos": [307, 492], "hip": 95294},
+                {"pos": [506, 100], "hip": 87072}
+              ]
+            },
+            "common_name": {"english": "Sagittarius", "pronounce": "Zhu"}
+          }
+        ]
+      }
+    ]
+  },
+  "asterisms": [
+    { "id": "AST arabic L00", "common_name": { "pronounce": "Al-Shartan", "english": "LM00", "translators_comments": "الشرطان" }, "lines": [[9884, 8903, 8832]] },
+    { "id": "AST arabic L01", "common_name": { "pronounce": "Al-Butayn", "english": "LM01", "translators_comments": "البطين" }, "lines": [[12719, 13061, 13209]] },
+    { "id": "AST arabic L02", "common_name": { "pronounce": "Al-Thurayya", "english": "LM02", "translators_comments": "الثريا" }, "lines": [[17847, 17608, 17702, 17499, 17573, 17531]] },
+    { "id": "AST arabic L03", "common_name": { "pronounce": "Al-Dabaran", "english": "LM03", "translators_comments": "الدبران" }, "lines": [[18724, 20205, 20713, 20894, 21421], [20205, 20455, 20648, 20889]] },
+    { "id": "AST arabic L04", "common_name": { "pronounce": "Al-Haqa", "english": "LM04", "translators_comments": "الحقا" }, "lines": [[26366, 26207, 26176], [27989, 26727, 27366], [26727, 26311, 25930], [25336, 25930, 24436], [26311, 26237, 26235, 26241]] },
+    { "id": "AST arabic L05", "common_name": { "pronounce": "Al-Hanʿa", "english": "LM05", "translators_comments": "الهنعة" }, "lines": [[28614, 27511, 29038, 27913, 29655, 29696, 27661, 28380, 27673]] },
+    { "id": "AST arabic L06", "common_name": { "pronounce": "Al-Dhiraʿ", "english": "LM06", "translators_comments": "الذراع" }, "lines": [[30343, 30883, 31681, 32362], [32246, 32921, 34088, 35350], [32921, 30883], [34088, 31681]] },
+    { "id": "AST arabic L07", "common_name": { "pronounce": "Al-Nathra", "english": "LM07", "translators_comments": "النثرة" }, "lines": [[41822, 41909, 42806, 42911, 41822]] },
+    { "id": "AST arabic L08", "common_name": { "pronounce": "Al-Tarf", "english": "LM08", "translators_comments": "الطرف" }, "lines": [[45336, 47431, 48356, 46390, 42402, 42799, 43109, 43813]] },
+    { "id": "AST arabic L09", "common_name": { "pronounce": "Al-Jabhah", "english": "LM09", "translators_comments": "الجبهة" }, "lines": [[49637, 49669], [47508, 49669, 49583, 50583], [47908, 48455, 50335, 50583, 47908]] },
+    { "id": "AST arabic L10", "common_name": { "pronounce": "Al-Zubrah", "english": "LM10", "translators_comments": "الزبرة" }, "lines": [[54872, 54879, 54182, 55434], [54879, 55642, 55434, 55137]] },
+    { "id": "AST arabic L11", "common_name": { "pronounce": "Al-Sarfah", "english": "LM11", "translators_comments": "الصرفة" }, "lines": [[57587, 56633, 55687, 54029, 52980], [55687, 56802], [50066, 51979, 54477, 56280, 57613], [54477, 54204, 51718, 54682, 55598, 53740, 52943], [55598, 57283, 58188], [57283, 55705, 53740], [55705, 55282, 58188]] },
+    { "id": "AST arabic L12", "common_name": { "pronounce": "Al-ʿAwwa", "english": "LM12", "translators_comments": "العوّاء" }, "lines": [[61359, 59316, 59803, 60965, 61359]] },
+    { "id": "AST arabic L13", "common_name": { "pronounce": "Al-Simak", "english": "LM13", "translators_comments": "السماك" }, "lines": [[65474, 66249]] },
+    { "id": "AST arabic L14", "common_name": { "pronounce": "Al-Ghafr", "english": "LM14", "translators_comments": "الغفر" }, "lines": [[69427, 69701, 70755], [69427, 69974]] },
+    { "id": "AST arabic L15", "common_name": { "pronounce": "Al-Zubana", "english": "LM15", "translators_comments": "الزُّبانا" }, "lines": [[76333, 73714, 72622, 74785]] },
+    { "id": "AST arabic L16", "common_name": { "pronounce": "Al-Iklil", "english": "LM16", "translators_comments": "الإكليل" }, "lines": [[80763, 80112, 78265], [80112, 78401], [80112, 78820], [80112, 79374], [80112, 80343]] },
+    { "id": "AST arabic L17", "common_name": { "pronounce": "Al-Qalb", "english": "LM17", "translators_comments": "القلب" }, "lines": [[83196, 81266, 82396]] },
+    { "id": "AST arabic L18", "common_name": { "pronounce": "Al-Shaulah", "english": "LM18", "translators_comments": "الشولة" }, "lines": [[82514, 80945, 82493], [82729, 84143, 86228, 87073, 86670, 85927], [86670, 87261]] },
+    { "id": "AST arabic L19", "common_name": { "pronounce": "Al-Naʿaim", "english": "LM19", "translators_comments": "النعايم" }, "lines": [[88635, 89931, 90185, 89642]] },
+    { "id": "AST arabic L20", "common_name": { "pronounce": "Al-Balda", "english": "LM20", "translators_comments": "البلدة" }, "lines": [[93864, 92855, 92041, 93506, 94986, 94114]] },
+    { "id": "AST arabic L21", "common_name": { "pronounce": "Saʿd al-Dhabiḥ", "english": "LM21", "translators_comments": "سعد الذابح" }, "lines": [[102618, 103045, 103005, 102624], [100064, 100345, 101027, 101123, 100881, 100345, 100310]] },
+    { "id": "AST arabic L22", "common_name": { "pronounce": "Saʿd al-Bulaʿ", "english": "LM22", "translators_comments": "سعد بلع" }, "lines": [[104987, 106278]] },
+    { "id": "AST arabic L23", "common_name": { "pronounce": "Saʿd al-Suʿud", "english": "LM23", "translators_comments": "سعد السعود" }, "lines": [[109427, 107315, 107348]] },
+    { "id": "AST arabic L24", "common_name": { "pronounce": "Saʿd al-Akhbiyah", "english": "LM24", "translators_comments": "سعد الأخبية" }, "lines": [[113881, 113963]] },
+    { "id": "AST arabic L25", "common_name": { "pronounce": "Al-Fargh al-Muqaddam", "english": "LM25", "translators_comments": "الفرغ المقدّم" }, "lines": [[677, 1067]] },
+    { "id": "AST arabic L26", "common_name": { "pronounce": "Al-Fargh al-Muʾakhkhar", "english": "LM26", "translators_comments": "الفرغ المؤخّر" }, "lines": [[5571, 5131, 3693, 3885, 3092, 4889, 2912, 4185], [5571, 5742, 4510, 5544, 4552, 5447, 4436, 4185]] },
+    { "id": "AST arabic L27", "common_name": { "pronounce": "Al-Risha (Al-Hūt)", "english": "LM27", "translators_comments": "الرشا/الحوت" }, "lines": [[4889, 6193, 5742, 7097, 8198, 9487]] }
+  ]
+}
+
+# Arabic_Tibetian_Lunar_Mansions
+
+## العنوان
+إنشاء ثقافة فلكية تجمع الأبراج التبتية بمنازل القمر العربية
+
+## المشروع
+تطوير ثقافة فلكية هجينة – Moon Houses in Samarra
+
+## المؤلف
+- الفيزيائي عمر الباز  
+- رئيس مبرمجين أقدم – شركة نقل الشمال للطاقة الكهربائية  
+- قسم شبكة كهرباء صلاح الدين  
+- عضو الاتحاد العربي لعلوم الفضاء والفلك  
+- باحث في علوم ما وراء الطبيعة  
+- مصمم ومصور فلكي  
+
+📧 البريد الإلكتروني: **omaralbaz127@gmail.com**  
+📱 رقم الهاتف: **009647716890986**
+
+## الغرض من الثقافة
+هذه النسخة المطوّرة من الثقافة الفلكية وُلدت لتعيد رسم السماء بلغة العرب،  
+لغة تُقرأ وتُرى وتُحس، منسوجة بين المنازل القمرية والأبراج التبتية،  
+في نسيج كوني واحد يجمع بين العلم والفن، بين التراث والحداثة.  
+
+إنها ليست مجرد خطوط بين النجوم، بل قصيدة سماوية،  
+مرآة للهوية، وجسر بين الماضي والمستقبل.  
+تهدف إلى تكريم التراث العربي، ودمج الأبراج التبتية،  
+وإضافة ألوان يونانية حديثة تمنح إحساساً بالجمال والسكينة،  
+لتكون الثقافة الفلكية لوحة كونية متكاملة.
+
+## المنازل القمرية
+28 منزلاً من الشرطين إلى الفرغ المؤخر، كل منزل يحمل رمزاً وحكمة.
+
+## الأبراج التبتية
+تتكامل مع المنازل العربية لتصنع رؤية هجينة  
+تكرّم التراث وتفتح أبواب المستقبل.
+
+## نجوم الناقة
+أضيفت مجموعة نجوم الناقة ومكوّناتها إلى الثقافة: **الناقة** ومكوناتها الفرعية (رأس الناقة، عنق الناقة، يدا الناقة، سنام الناقة، والثريا). فيما يلي قائمة النجوم (HIP/DSO) المرتبطة بكل جزء كما وُثّقت في ملفات المشروع:
+
+- **الناقة — The She-Camel**  
+  HIP116631; HIP116805; HIP116584; HIP117221; HIP841; HIP2225; HIP2900; HIP3414; HIP3504; HIP3300; HIP2920; HIP3179; HIP746; HIP2599; HIP8886; HIP4427; HIP6686; HIP5251; HIP8068; HIP4998; HIP7607
+
+- **رأس الناقة — Head Of The She-Camel**  
+  HIP116631; HIP116805; HIP116584; HIP117221
+
+- **عنق الناقة — Neck Of The She-Camel**  
+  HIP117221; HIP841; HIP2225; HIP2900; HIP3414; HIP3504; HIP3300; HIP2920
+
+- **يدا الناقة — Legs Of The She-Camel**  
+  HIP5251; HIP8068; HIP4998; HIP7607
+
+- **سنام الناقة — The She-Camel's Hump**  
+  HIP2920; HIP746; HIP2599; HIP8886; HIP6686; HIP4427; HIP3179
+
+- **الثريا [الرأس واليدان] — Al-Thurayya [The head and the two hands]**  
+  HIP14135; HIP13954; HIP12828; HIP12706; HIP11484; HIP746; HIP3179; HIP4427; HIP6686; HIP8886; DSO:NGC869; DSO:NGC884; HIP13268; HIP14328; HIP17358; HIP18532; HIP18614; HIP18246; DSO:M45; HIP17448; HIP17460; HIP17529; HIP16335; HIP15863; HIP16369; HIP16083; HIP15900
+
+> **ملاحظة**: الأرقام أعلاه مأخوذة من ملفات المشروع (`index.json` و`constellation.json`) وتستخدم نمط HIP/DSO كما هو موثّق. تأكد من أن قواعد بيانات النجوم لديك تحتوي هذه المراجع قبل أي عملية عرض أو تحليل.
+
+## الرؤية
+- العلم يمكن أن يكون جميلاً  
+- التراث يمكن أن يعيش في لغة حديثة  
+- السماء مرآة الهوية وجسر بين الماضي والمستقبل  
+
+## المراجع
+1. Burgess, E. (1860). Surya-Siddhanta – Hindu Astronomy.  
+2. Cornu, P. (2002). Tibetan Astrology. Shambhala.  
+3. Reingold & Dershowitz (2018). Calendrical Calculations. Cambridge University Press.  
+
+## حقوق النشر
+CC BY-SA  
+المكان: سامراء – العراق  
+التوقيع: عمر الباز
+
+{
+  "id": "Arabic_tibetian_lunar_mansions",
+  "region": "Arab World",
+  "classification": ["ethnographic"],
+  "fallback_to_international_names": false,
+  "constellations": [
+    {
+      "id": "CON tibetan Lib",
+      "lines": [[77853, 76333, 74785, 72622, 73714, 76333]],
+      "image": {
+        "file": "illustrations/libra.png",
+        "size": [256, 256],
+        "anchors": [
+          {"pos": [41, 27], "hip": 74785},
+          {"pos": [58, 170], "hip": 77853},
+          {"pos": [224, 107], "hip": 73714}
+        ]
+      },
+      "common_name": {"english": "Libra", "pronounce": "Sangwa"}
+    },
+    {
+      "id": "CON tibetan Ari",
+      "lines": [[13209, 9884, 8903, 8832]],
+      "image": {
+        "file": "illustrations/aries.png",
+        "size": [256, 256],
+        "anchors": [
+          {"pos": [12, 130], "hip": 13209},
+          {"pos": [58, 206], "hip": 13914},
+          {"pos": [210, 47], "hip": 8832}
+        ]
+      },
+      "common_name": {"english": "Aries", "pronounce": "Luk"}
+    },
+    {
+      "id": "CON tibetan Boo",
+      "lines": [[71795, 69673, 72105, 74666, 73555, 71075, 71053, 69673, 67927, 67459]],
+      "common_name": {"english": ""},
+      "comment": "For orientation only. Non-Tibetan!"
+    },
+    {
+      "id": "CON tibetan Cnc",
+      "lines": [[43103, 42806, 40843], [42806, 42911, 40526], [42911, 44066]],
+      "image": {
+        "file": "illustrations/cancer.png",
+        "size": [256, 256],
+        "anchors": [
+          {"pos": [29, 166], "hip": 44066},
+          {"pos": [101, 255], "hip": 40526},
+          {"pos": [206, 91], "hip": 40843}
+        ]
+      },
+      "common_name": {"english": "Cancer", "pronounce": "Karkata"}
+    },
+    {
+      "id": "CON tibetan Cap",
+      "lines": [[100064, 100345, 104139, 105515, 106985, 107556], [105515, 105881, 104139], [100345, 102485], [104139, 102978]],
+      "image": {
+        "file": "illustrations/capricornus.png",
+        "size": [512, 512],
+        "anchors": [
+          {"pos": [15, 436], "hip": 107556},
+          {"pos": [403, 7], "hip": 100064},
+          {"pos": [460, 438], "hip": 102978}
+        ]
+      },
+      "common_name": {"english": "Capricornus", "pronounce": "Chusin"}
+    },
+    {
+      "id": "CON tibetan Cas",
+      "lines": [[8886, 6686, 4427, 3179, 746]],
+      "common_name": {"english": ""},
+      "comment": "For orientation only. Non-Tibetan!"
+    },
+    {
+      "id": "CON tibetan Cyg",
+      "lines": [[94779, 95853, 97165, 100453, 102098], [100453, 102488, 104732, 107310], [100453, 98110, 95947]],
+      "common_name": {"english": ""},
+      "comment": "For orientation only. Non-Tibetan!"
+    },
+    {
+      "id": "CON tibetan Gem",
+      "lines": [[31681, 34088, 35550, 35350, 32362], [35550, 36962, 37740], [36962, 37826], [36962, 36046, 34693, 36850], [34693, 33018], [34693, 32246, 30883], [32246, 30343, 29655, 28734]],
+      "image": {
+        "file": "illustrations/gemini.png",
+        "size": [256, 256],
+        "anchors": [
+          {"pos": [14, 81], "hip": 37740},
+          {"pos": [117, 252], "hip": 32362},
+          {"pos": [249, 165], "hip": 28734}
+        ]
+      },
+      "common_name": {"english": "Gemini", "pronounce": "Trik"}
+    },
+    {
+      "id": "CON tibetan UMa",
+      "lines": [[67301, 65378, 62956, 59774, 54061, 53910, 58001, 59774]],
+      "common_name": {"english": ""},
+      "comment": "For orientation only. Non-Tibetan or names unknown!"
+    },
+    {
+      "id": "CON tibetan Leo",
+      "lines": [[57632, 54879, 49669, 49583, 50583, 54872, 57632], [50583, 50335, 48455, 47908], [54872, 54879]],
+      "image": {
+        "file": "illustrations/leo.png",
+        "size": [512, 512],
+        "anchors": [
+          {"pos": [69, 411], "hip": 57632},
+          {"pos": [383, 186], "hip": 49669},
+          {"pos": [321, 32], "hip": 47908}
+        ]
+      },
+      "common_name": {"english": "Leo", "pronounce": "Senge"}
+    },
+    {
+      "id": "CON tibetan Lyr",
+      "lines": [[91262, 91971, 92420, 93194, 92791, 91971]],
+      "common_name": {"english": ""}
+    },
+    {
+      "id": "CON tibetan UMi",
+      "lines": [[11767, 85822, 82080, 77055, 79822, 75097, 72607, 77055]],
+      "common_name": {"english": ""},
+      "comment": "For orientation only. Non-Tibetan!"
+    },
+    {
+      "id": "CON tibetan Psc",
+      "lines": [[4889, 5742], [4889, 6193, 5742, 7097, 8198, 9487, 8833, 7884, 7007, 4906, 3760, 1645, 118268, 116771, 116928, 115738, 114971, 115830, 116771]],
+      "image": {
+        "file": "illustrations/pisces.png",
+        "size": [512, 512],
+        "anchors": [
+          {"pos": [24, 104], "hip": 4889},
+          {"pos": [111, 489], "hip": 9487},
+          {"pos": [481, 155], "hip": 114971}
+        ]
+      },
+      "common_name": {"english": "Pisces", "pronounce": "Nya"}
+    },
+    {
+      "id": "CON tibetan Sgr",
+      "lines": [[89931, 90496], [89642, 90185, 88635, 87072], [88635, 89931, 90185, 93506, 92041, 89931], [92041, 90496, 89341], [93506, 93864, 92855, 92041], [92855, 93085, 93683, 94820, 95168], [93864, 96406, 98688, 98412, 98032, 95347], [98032, 95294]],
+      "image": {
+        "file": "illustrations/sagittarius.png",
+        "size": [512, 512],
+        "anchors": [
+          {"pos": [96, 82], "hip": 95168},
+          {"pos": [307, 492], "hip": 95294},
+          {"pos": [506, 100], "hip": 87072}
+        ]
+      },
+      "common_name": {"english": "Sagittarius", "pronounce": "Zhu"}
+    },
+    {
+      "id": "CON tibetan Sco",
+      "lines": [[85927, 86670, 87073, 86228, 84143, 82671, 82514, 82396, 81266, 80763, 80112, 78401], [80112, 78265], [80112, 78820]],
+      "image": {
+        "file": "illustrations/scorpius.png",
+        "size": [512, 512],
+        "anchors": [
+          {"pos": [447, 29], "hip": 78820},
+          {"pos": [62, 365], "hip": 85927},
+          {"pos": [217, 462], "hip": 82729}
+        ]
+      },
+      "common_name": {"english": "Scorpius", "pronounce": "Dikpa"}
+    },
+    {
+      "id": "CON tibetan Tau",
+      "lines": [[25428, 21881, 20889], [21421, 26451], [20205, 20455], [20205, 18724, 15900], [21421, 20889], [21421, 20894, 20205], [20889, 20648, 20455, 17847]],
+      "image": {
+        "file": "illustrations/taurus.png",
+        "size": [512, 512],
+        "anchors": [
+          {"pos": [13, 92], "hip": 26451},
+          {"pos": [399, 438], "hip": 15900},
+          {"pos": [382, 192], "hip": 17999}
+        ]
+      },
+      "common_name": {"english": "Taurus", "pronounce": "Lang"}
+    },
+    {
+      "id": "CON tibetan Aqr",
+      "lines": [[106278, 109074, 110395, 110960, 111497, 112961, 114855, 115438], [109074, 110003, 109139], [110003, 111123, 112716, 113136, 114341], [102618, 106278]],
+      "image": {
+        "file": "illustrations/aquarius.png",
+        "size": [512, 512],
+        "anchors": [
+          {"pos": [144, 464], "hip": 115438},
+          {"pos": [179, 98], "hip": 109074},
+          {"pos": [465, 49], "hip": 102618}
+        ]
+      },
+      "common_name": {"english": "Aquarius", "pronounce": "Bumpa"}
+    },
+    {
+      "id": "CON tibetan Vir",
+      "lines": [[57380, 60030, 61941, 65474, 69427, 69701, 71957], [65474, 66249, 68520, 72220], [66249, 63090, 63608], [63090, 61941]],
+      "image": {
+        "file": "illustrations/virgo.png",
+        "size": [512, 512],
+        "anchors": [
+          {"pos": [65, 389], "hip": 72220},
+          {"pos": [454, 57], "hip": 57380},
+          {"pos": [338, 382], "hip": 65474}
+        ]
+      },
+      "common_name": {"english": "Virgo", "pronounce": "Pumo"}
+    },
+
+    {
+      "id": "CON arabic_indigenous Naqa",
+      "lines": [
+        [116631, 116805, 116584, 117221, 841, 2225, 2900, 3414, 3504, 3300, 2920, 3179, 746, 2599, 8886],
+        [2920, 746],
+        [3179, 4427, 2599],
+        [4427, 6686, 8886],
+        [6686, "DSO:NGC869"],
+        [5251, 8068],
+        [4998, 7607]
+      ],
+      "common_name": {
+        "english": "The She-Camel",
+        "native": "الناقة",
+        "pronounce": "al-Nāqah",
+        "transliteration": "al-Nāqah",
+        "IPA": "an.naː.qah",
+        "references": [1,2,4]
+      }
+    },
+    {
+      "id": "CON arabic_indigenous RNaq",
+      "lines": [[116631, 116805, 116584, 117221]],
+      "common_name": {
+        "english": "Head Of The She-Camel",
+        "native": "رأس الناقة",
+        "pronounce": "Ra's al-Nāqah",
+        "transliteration": "Raʾs al-Nāqah",
+        "IPA": "raʔ.su.n.naː.qa.h",
+        "references": [1,2,4]
+      }
+    },
+    {
+      "id": "CON arabic_indigenous UNaq",
+      "lines": [[117221, 841, 2225, 2900, 3414, 3504, 3300, 2920]],
+      "common_name": {
+        "english": "Neck Of The She-Camel",
+        "native": "عنق الناقة",
+        "pronounce": "'Unuq al-Nāqah",
+        "transliteration": "ʿUnuq al-Nāqah",
+        "IPA": "ʕu.nu.qu.n.naː.qah",
+        "references": [1,2,4]
+      }
+    },
+    {
+      "id": "CON arabic_indigenous YNaq",
+      "lines": [[5251, 8068], [4998, 7607]],
+      "common_name": {
+        "english": "Legs Of The She-Camel",
+        "native": "يدا الناقة",
+        "pronounce": "Yadā al-Nāqah",
+        "transliteration": "Yadā al-Nāqah",
+        "IPA": "ja.daːn.naː.qah",
+        "references": [4]
+      }
+    },
+    {
+      "id": "CON arabic_indigenous SNaq",
+      "lines": [[2920, 746, 2599, 8886, 6686, 4427, 3179, 2920]],
+      "common_name": {
+        "english": "The She-Camel's Hump",
+        "native": "سنام الناقة",
+        "pronounce": "Sanām al-Nāqah",
+        "transliteration": "Sanām al-Nāqah",
+        "IPA": "sa.naːmun.naː.qah",
+        "references": [1,2,3,4]
+      }
+    },
+    {
+      "id": "CON arabic_indigenous ThuI",
+      "lines": [
+        [14135, 13954, 12828],
+        [14135, 12706, 11484],
+        [14135, 12387, 11484],
+        [746, 3179, 4427, 6686, 8886, 6686, "DSO:NGC869", "DSO:NGC884", 13268, 14328, 17358, 18532, 18614, 18246, "DSO:M45", 17448, 17460, 17529, 16335, 15863, 14328],
+        ["DSO:M45", 16369, 14135],
+        ["DSO:M45", 16322, 16083, 15900, 14135]
+      ],
+      "label_positions": [[3.72, 24.37], [3.45, 12.74], [2.72, 55.10]],
+      "common_name": {
+        "english": "Al-Thurayya [The head and the two hands]",
+        "native": "الثريا [الرأس واليدان]",
+        "pronounce": "al-Thurayyā [al-Ra's wa al-Yadān]",
+        "transliteration": "al-Ṯurayyā [al-Raʾs wa al-Yadān]",
+        "IPA": "aθθu.rajj.jaː [ar.raʔ.su.wal.yadaːn]",
+        "references": [1,2,3,4]
+      }
+    }
+
+  ],
+  "asterisms": [
+    { "id": "AST arabic L00", "common_name": { "pronounce": "Al-Shartan", "english": "LM00", "translators_comments": "الشرطان" }, "lines": [[9884, 8903, 8832]] },
+    { "id": "AST arabic L01", "common_name": { "pronounce": "Al-Butayn", "english": "LM01", "translators_comments": "البطين" }, "lines": [[12719, 13061, 13209]] },
+    { "id": "AST arabic L02", "common_name": { "pronounce": "Al-Thurayya", "english": "LM02", "translators_comments": "الثريا" }, "lines": [[17847, 17608, 17702, 17499, 17573, 17531]] },
+    { "id": "AST arabic L03", "common_name": { "pronounce": "Al-Dabaran", "english": "LM03", "translators_comments": "الدبران" }, "lines": [[18724, 20205, 20713, 20894, 21421], [20205, 20455, 20648, 20889]] },
+    { "id": "AST arabic L04", "common_name": { "pronounce": "Al-Haqa", "english": "LM04", "translators_comments": "الحقا" }, "lines": [[26366, 26207, 26176], [27989, 26727, 27366], [26727, 26311, 25930], [25336, 25930, 24436], [26311, 26237, 26235, 26241]] },
+    { "id": "AST arabic L05", "common_name": { "pronounce": "Al-Hanʿa", "english": "LM05", "translators_comments": "الهنعة" }, "lines": [[28614, 27511, 29038, 27913, 29655, 29696, 27661, 28380, 27673]] },
+    { "id": "AST arabic L06", "common_name": { "pronounce": "Al-Dhiraʿ", "english": "LM06", "translators_comments": "الذراع" }, "lines": [[30343, 30883, 31681, 32362], [32246, 32921, 34088, 35350], [32921, 30883], [34088, 31681]] },
+    { "id": "AST arabic L07", "common_name": { "pronounce": "Al-Nathra", "english": "LM07", "translators_comments": "النثرة" }, "lines": [[41822, 41909, 42806, 42911, 41822]] },
+    { "id": "AST arabic L08", "common_name": { "pronounce": "Al-Tarf", "english": "LM08", "translators_comments": "الطرف" }, "lines": [[45336, 47431, 48356, 46390, 42402, 42799, 43109, 43813]] },
+    { "id": "AST arabic L09", "common_name": { "pronounce": "Al-Jabhah", "english": "LM09", "translators_comments": "الجبهة" }, "lines": [[49637, 49669], [47508, 49669, 49583, 50583], [47908, 48455, 50335, 50583, 47908]] },
+    { "id": "AST arabic L10", "common_name": { "pronounce": "Al-Zubrah", "english": "LM10", "translators_comments": "الزبرة" }, "lines": [[54872, 54879, 54182, 55434], [54879, 55642, 55434, 55137]] },
+    { "id": "AST arabic L11", "common_name": { "pronounce": "Al-Sarfah", "english": "LM11", "translators_comments": "الصرفة" }, "lines": [[57587, 56633, 55687, 54029, 52980], [55687, 56802], [50066, 51979, 54477, 56280, 57613], [54477, 54204, 51718, 54682, 55598, 53740, 52943], [55598, 57283, 58188], [57283, 55705, 53740], [55705, 55282, 58188]] },
+    { "id": "AST arabic L12", "common_name": { "pronounce": "Al-ʿAwwa", "english": "LM12", "translators_comments": "العوّاء" }, "lines": [[61359, 59316, 59803, 60965, 61359]] },
+    { "id": "AST arabic L13", "common_name": { "pronounce": "Al-Simak", "english": "LM13", "translators_comments": "السماك" }, "lines": [[65474, 66249]] },
+    { "id": "AST arabic L14", "common_name": { "pronounce": "Al-Ghafr", "english": "LM14", "translators_comments": "الغفر" }, "lines": [[69427, 69701, 70755], [69427, 69974]] },
+    { "id": "AST arabic L15", "common_name": { "pronounce": "Al-Zubana", "english": "LM15", "translators_comments": "الزُّبانا" }, "lines": [[76333, 73714, 72622, 74785]] },
+    { "id": "AST arabic L16", "common_name": { "pronounce": "Al-Iklil", "english": "LM16", "translators_comments": "الإكليل" }, "lines": [[80763, 80112, 78265], [80112, 78401], [80112, 78820], [80112, 79374], [80112, 80343]] },
+    { "id": "AST arabic L17", "common_name": { "pronounce": "Al-Qalb", "english": "LM17", "translators_comments": "القلب" }, "lines": [[83196, 81266, 82396]] },
+    { "id": "AST arabic L18", "common_name": { "pronounce": "Al-Shaulah", "english": "LM18", "translators_comments": "الشولة" }, "lines": [[82514, 80945, 82493], [82729, 84143, 86228, 87073, 86670, 85927], [86670, 87261]] },
+    { "id": "AST arabic L19", "common_name": { "pronounce": "Al-Naʿaim", "english": "LM19", "translators_comments": "النعايم" }, "lines": [[88635, 89931, 90185, 89642]] },
+    { "id": "AST arabic L20", "common_name": { "pronounce": "Al-Balda", "english": "LM20", "translators_comments": "البلدة" }, "lines": [[93864, 92855, 92041, 93506, 94986, 94114]] },
+    { "id": "AST arabic L21", "common_name": { "pronounce": "Saʿd al-Dhabiḥ", "english": "LM21", "translators_comments": "سعد الذابح" }, "lines": [[102618, 103045, 103005, 102624], [100064, 100345, 101027, 101123, 100881, 100345, 100310]] },
+    { "id": "AST arabic L22", "common_name": { "pronounce": "Saʿd al-Bulaʿ", "english": "LM22", "translators_comments": "سعد بلع" }, "lines": [[104987, 106278]] },
+    { "id": "AST arabic L23", "common_name": { "pronounce": "Saʿd al-Suʿud", "english": "LM23", "translators_comments": "سعد السعود" }, "lines": [[109427, 107315, 107348]] },
+    { "id": "AST arabic L24", "common_name": { "pronounce": "Saʿd al-Akhbiyah", "english": "LM24", "translators_comments": "سعد الأخبية" }, "lines": [[113881, 113963]] },
+    { "id": "AST arabic L25", "common_name": { "pronounce": "Al-Fargh al-Muqaddam", "english": "LM25", "translators_comments": "الفرغ المقدّم" }, "lines": [[677, 1067]] },
+    { "id": "AST arabic L26", "common_name": { "pronounce": "Al-Fargh al-Muʾakhkhar", "english": "LM26", "translators_comments": "الفرغ المؤخّر" }, "lines": [[5571, 5131, 3693, 3885, 3092, 4889, 2912, 4185], [5571, 5742, 4510, 5544, 4552, 5447, 4436, 4185]] },
+    { "id": "AST arabic L27", "common_name": { "pronounce": "Al-Risha (Al-Hūt)", "english": "LM27", "translators_comments": "الرشا/الحوت" }, "lines": [[4889, 6193, 5742, 7097, 8198, 9487]] }
+  ],
+  "zodiac": {
+    "name": { "english": "Arabic Zodiac" },
+    "context": "arabic zodiac sign",
+    "comment": "Shaped after the Arabic zodiac. Enhanced by Arabic names. المصمم والمطور الفيزيائي عمر الباز، رئيس مبرمجين أقدم، وزارة الكهرباء العراقية، وعضو الاتحاد العربي لعلوم الفضاء والفلك",
+    "partitions": [12, 3, 2, 5],
+    "extent": 9,
+    "link": { "star": 65474, "offset": 180 },
+    "names": [
+      { "symbol": "♈", "pronounce": "Al-Hamal", "english": "Ram" },
+      { "symbol": "♉", "pronounce": "Al-Thawr", "english": "Bull" },
+      { "symbol": "♊", "pronounce": "Al-Jawzaʾ", "english": "Twins" },
+      { "symbol": "♋", "pronounce": "Al-Saratan", "english": "Crab" },
+      { "symbol": "♌", "pronounce": "Al-Asad", "english": "Lion" },
+      { "symbol": "♍", "pronounce": "Al-Sunbula", "english": "Virgin" },
+      { "symbol": "♎", "pronounce": "Al-Mizan", "english": "Scales" },
+      { "symbol": "♏", "pronounce": "Al-ʿAqrab", "english": "Scorpion" },
+      { "symbol": "♐", "pronounce": "Al-Qaws", "english": "Archer" },
+      { "symbol": "♑", "pronounce": "Al-Jady", "english": "Capricorn" },
+      { "symbol": "♒", "pronounce": "Al-Dalw", "english": "Water bearer" },
+      { "symbol": "♓", "pronounce": "Al-Hut", "english": "Fishes" }
+    ]
+  },
+  "lunar_system": {
+    "name": { "pronounce": "Manazil Qamariyya", "english": "Arabic Lunar Mansions" },
+    "context": "arabic lunar mansion",
+    "comment": "Shaped after the Arabic 28 lunar mansions. Enhanced by Arabic names.",
+    "partitions": [28],
+    "extent": 5,
+    "link": { "star": 65474, "offset": 180 },
+    "names": [
+      { "symbol": "0", "pronounce": "Al-Shartan" },
+      { "symbol": "1", "pronounce": "Al-Butayn" },
+      { "symbol": "2", "pronounce": "Al-Thurayya" },
+      { "symbol": "3", "pronounce": "Al-Dabaran" },
+      { "symbol": "4", "pronounce": "Al-Haqa" },
+      { "symbol": "5", "pronounce": "Al-Hanʿa" },
+      { "symbol": "6", "pronounce": "Al-Dhiraʿ" },
+      { "symbol": "7", "pronounce": "Al-Nathra" },
+      { "symbol": "8", "pronounce": "Al-Tarf" },
+      { "symbol": "9", "pronounce": "Al-Jabhah" },
+      { "symbol": "10", "pronounce": "Al-Zubrah" },
+      { "symbol": "11", "pronounce": "Al-Sarfah" },
+      { "symbol": "12", "pronounce": "Al-ʿAwwa" },
+      { "symbol": "13", "pronounce": "Al-Simak" },
+      { "symbol": "14", "pronounce": "Al-Ghafr" },
+      { "symbol": "15", "pronounce": "Al-Zubana" },
+      { "symbol": "16", "pronounce": "Al-Iklil" },
+      { "symbol": "17", "pronounce": "Al-Qalb" },
+      { "symbol": "18", "pronounce": "Al-Shaulah" },
+      { "symbol": "19", "pronounce": "Al-Naʿaim" },
+      { "symbol": "20", "pronounce": "Al-Balda" },
+      { "symbol": "21", "pronounce": "Saʿd al-Dhabiḥ" },
+      { "symbol": "22", "pronounce": "Saʿd al-Bulaʿ" },
+      { "symbol": "23", "pronounce": "Saʿd al-Suʿud" },
+      { "symbol": "24", "pronounce": "Saʿd al-Akhbiyah" },
+      { "symbol": "25", "pronounce": "Al-Fargh al-Muqaddam" },
+      { "symbol": "26", "pronounce": "Al-Fargh al-Muʾakhkhar" },
+      { "symbol": "27", "pronounce": "Al-Risha (Al-Hūt)" }
+    ]
+  }
+}
+
+[info]
+id = Arabic_tibetian_lunar_mansions
+name = Moon Houses in Samarra (المنازل القمرية في سامراء)
+author = الفيزيائي عمر الباز - رئيس مبرمجين أقدم / وزارة الكهرباء العراقية - عضو الاتحاد العربي لعلوم الفضاء والفلك
+version = 1.2
+license = CC BY-SA 4.0
+short_description = Enhanced astronomical culture of the 28 Arabic lunar mansions, developed in Samarra.
+long_description = In the sky of Samarra, where history whispers to the stars, this celestial culture redraws the heavens in the language of the Arabs. Twenty-eight stations, from Al-Sharaṭayn to Al-Fargh al-Mu’akhkhar, each bearing a name, a symbol, and wisdom from our ancient heritage. The crescent moon passes through them month after month, as it has for millennia. This culture is a bridge between past and future, science and art.
+lang = ar,en
+last_modified = 2025-11-25
+maintainer = proph
+
+[Counts]
+# عدد الإدخالات المضافة مؤخراً
+constellations_added = 6
+# ضع هنا العدد الكلي للمجموعات بعد التحديث إن رغبت
+# constellations_total = 
+
+[Changes]
+# سجل مختصر بالتغييرات الأخيرة
+added = CON arabic_indigenous Naqa; CON arabic_indigenous RNaq; CON arabic_indigenous UNaq; CON arabic_indigenous YNaq; CON arabic_indigenous SNaq; CON arabic_indigenous ThuI
+changelog = 2025-11-25: Added "The She-Camel" group and its subparts; reorganized constellations into sections.
+
+[Assets]
+# أضف هنا أي ملفات صور أو مراجع جديدة مستخدمة
+# مثال: illustrations/naqa.png = used_by CON arabic_indigenous Naqa
+# مثال: DSO references مثل "DSO:NGC869" و "DSO:M45" مذكورة داخل index.json
+
+[Compatibility]
+# إن كانت أدواتك تتوقع أن constellations مصفوفة مباشرة، اضبط القارئ ليتعامل مع sections
+notes = constellations are organized into sections under index.json; readers should extract sections[*].constellations
+
+[display]
+locale_default = ar
+line_color = 0.90,0.75,0.30,1.0
+label_color = 0.95,0.95,0.85,1.0
+label_font_size = 18
+show_as_outline = true


### PR DESCRIPTION
…on lines

This commit adds a hybrid astronomical culture combining Arabic lunar mansions with Tibetan zodiac. Includes Arabic constellation names and line definitions.